### PR TITLE
Update caniuse.com link

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,7 +94,7 @@
       This is a list of sites that are hardcoded into Chrome as being HTTPS only.
     </p>
     <p>
-      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="http://caniuse.com/#feat=stricttransportsecurity">HSTS compatibility matrix</a>.)
+      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="https://caniuse.com/stricttransportsecurity">HSTS compatibility matrix</a>.)
     </p>
   </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,7 +94,7 @@
       This is a list of sites that are hardcoded into Chrome as being HTTPS only.
     </p>
     <p>
-      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="https://caniuse.com/stricttransportsecurity">HSTS compatibility matrix</a>.)
+      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="http://caniuse.com/stricttransportsecurity">HSTS compatibility matrix</a>.)
     </p>
   </section>
 


### PR DESCRIPTION
Their internal link structure changed. Also use an HTTPS URL.