### PR TITLE
Convert domain to lowercase during ASCII normalization in the API handlers.

### DIFF
--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -12,6 +12,15 @@ import (
 	"github.com/chromium/hstspreload.org/database"
 )
 
+func normalizeDomain(unicode string) (string, error) {
+	ascii, err := idna.ToASCII(unicode)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ToLower(ascii), nil
+}
+
 func getASCIIDomain(wantMethod string, w http.ResponseWriter, r *http.Request) (ascii string, ok bool) {
 	if r.Method != wantMethod {
 		http.Error(w, fmt.Sprintf("Wrong method. Requires %s.", wantMethod), http.StatusMethodNotAllowed)
@@ -24,14 +33,14 @@ func getASCIIDomain(wantMethod string, w http.ResponseWriter, r *http.Request) (
 		return "", false
 	}
 
-	ascii, err := idna.ToASCII(unicode)
+	normalized, err := normalizeDomain(unicode)
 	if err != nil {
 		msg := fmt.Sprintf("Internal error: not convert domain to ASCII. (%s)\n", err)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return "", false
 	}
 
-	return strings.ToLower(ascii), true
+	return normalized, true
 }
 
 // Preloadable takes a single domain and returns if it is preloadable.

--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"golang.org/x/net/idna"
@@ -30,7 +31,7 @@ func getASCIIDomain(wantMethod string, w http.ResponseWriter, r *http.Request) (
 		return "", false
 	}
 
-	return ascii, true
+	return strings.ToLower(ascii), true
 }
 
 // Preloadable takes a single domain and returns if it is preloadable.

--- a/api/domain_handlers_test.go
+++ b/api/domain_handlers_test.go
@@ -1,0 +1,26 @@
+package api
+
+import "testing"
+
+var normalizeDomainTests = []struct {
+	input    string
+	expected string
+}{
+	{"example.com", "example.com"},
+	{"EXAMPLE.com", "example.com"},
+	{"example.рф", "example.xn--p1ai"},
+	{"WWW.müller.de", "www.xn--mller-kva.de"},
+	{"eXamPle.coM", "example.com"},
+}
+
+func TestNormalizeDomain(t *testing.T) {
+	for _, c := range normalizeDomainTests {
+		result, err := normalizeDomain(c.input)
+		if err != nil {
+			t.Error(err)
+		}
+		if c.expected != result {
+			t.Errorf("normalizeDomain(%q) => %q, want %q", c.input, result, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
The API currently considers domain.tld and dOmain.tld to be 2 different domains and allows all variations to be preloaded separately.

The domain names should be processed in a case-insensitive way.

The frontend converts domain names to lowercase [1] but the API does not.

[1] https://github.com/chromium/hstspreload.org/blob/master/frontend/static/js/base.js#L31