### PR TITLE
Increase number of probes.

### DIFF
--- a/database/gcd/gcd.go
+++ b/database/gcd/gcd.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	numLocalProbes    = 10
+	numLocalProbes    = 20
 	initialProbeSleep = 500 * time.Millisecond
 	localProbeSpacing = 250 * time.Millisecond
 )


### PR DESCRIPTION
Double the number of probes to prevent premature aborts on waiting for the local GCD environment to spin up.

Fixes #99.