### PR TITLE
Show issues for preloaded domains

### DIFF
--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -12,6 +12,12 @@ import (
 	"github.com/chromium/hstspreload.org/database"
 )
 
+// DomainStateWithBulk is a DomainState that also includes information about the bulk status of the domain.
+type DomainStateWithBulk struct {
+	*database.DomainState
+	Bulk bool `json:"bulk"`
+}
+
 func normalizeDomain(unicode string) (string, error) {
 	ascii, err := idna.ToASCII(unicode)
 	if err != nil {
@@ -130,7 +136,11 @@ func (api API) Status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	state.Name = domain
-	writeJSONOrBust(w, state)
+	bulkState := DomainStateWithBulk{
+		DomainState: &state,
+		Bulk:        api.bulkPreloaded[domain],
+	}
+	writeJSONOrBust(w, bulkState)
 }
 
 // Submit takes a single domain and attempts to submit it to the

--- a/frontend/static/js/form.js
+++ b/frontend/static/js/form.js
@@ -104,17 +104,16 @@ function statusString(status, issues, domain) {
       return 'Status: ' + domain + ' is pending submission to the preload list.';
     case 'preloaded':
       if (status.bulk) {
-        return 'Status: ' + domain + ' is currently preloaded.';
-      } else {
         switch (worstIssues(issues)) {
-          case 'none':
-            return 'Status: ' + domain + ' is currently preloaded.';
           case 'warnings':
+            return 'Status: ' + domain + ' is currently preloaded, but has the following issues:';
           case 'errors':
-            return 'Status: ' + domain + ' is currently preloaded, but missing current requirements.';
+            return 'Status: ' + domain + ' is currently preloaded, but no longer meets the requirements. It may be at risk of removal.';
           default:
-            return 'Status: ' + domain + ' is currently preloaded, but unable to determine if it meets current requirements.';
+            return 'Status: ' + domain + ' is currently preloaded.';
         }
+      } else {
+        return 'Status: ' + domain + ' is currently preloaded.';
       }
       break;
 
@@ -248,7 +247,9 @@ PreloadController.prototype = {
         break;
       case 'preloaded':
         view.setTheme('theme-green');
-        view.showIssues(issues);
+        if (status.bulk) {
+          view.showIssues(issues);
+        }
         break;
       default:
         throw "Unknown status";

--- a/frontend/static/js/form.js
+++ b/frontend/static/js/form.js
@@ -96,14 +96,23 @@ Form.prototype = {
   }
 };
 
-function statusString(status, domain) {
+function statusString(status, issues, domain) {
   switch (status.status) {
     case 'unknown':
       return 'Status: ' + domain + ' is not preloaded.';
     case 'pending':
       return 'Status: ' + domain + ' is pending submission to the preload list.';
     case 'preloaded':
-      return 'Status: ' + domain + ' is currently preloaded.'
+      switch (worstIssues(issues)) {
+        case 'none':
+          return 'Status: ' + domain + ' is currently preloaded.';
+        case 'warnings':
+        case 'errors':
+          return 'Status: ' + domain + ' is currently preloaded, but missing current requirements.';
+        default:
+          return 'Status: ' + domain + ' is currently preloaded, but unable to determine if it meets current requirements.';
+      }
+      break;      
 
     case 'rejected':
       if (status.message) {
@@ -216,7 +225,7 @@ PreloadController.prototype = {
 
   showResults: function(view, domain, issues, status) {
 
-    view.setStatus(statusString(status, domain));
+    view.setStatus(statusString(status, issues, domain));
 
     var showForm = false;
 
@@ -235,6 +244,7 @@ PreloadController.prototype = {
         break;
       case 'preloaded':
         view.setTheme('theme-green');
+        view.showIssues(issues);
         break;
       default:
         throw "Unknown status";
@@ -299,7 +309,7 @@ RemovalController.prototype = {
 
   showResults: function(view, domain, issues, status) {
 
-    view.setStatus(statusString(status, domain));
+    view.setStatus(statusString(status, issues, domain));
 
     var showForm = false;
 

--- a/frontend/static/js/form.js
+++ b/frontend/static/js/form.js
@@ -103,16 +103,20 @@ function statusString(status, issues, domain) {
     case 'pending':
       return 'Status: ' + domain + ' is pending submission to the preload list.';
     case 'preloaded':
-      switch (worstIssues(issues)) {
-        case 'none':
-          return 'Status: ' + domain + ' is currently preloaded.';
-        case 'warnings':
-        case 'errors':
-          return 'Status: ' + domain + ' is currently preloaded, but missing current requirements.';
-        default:
-          return 'Status: ' + domain + ' is currently preloaded, but unable to determine if it meets current requirements.';
+      if (status.bulk) {
+        return 'Status: ' + domain + ' is currently preloaded.';
+      } else {
+        switch (worstIssues(issues)) {
+          case 'none':
+            return 'Status: ' + domain + ' is currently preloaded.';
+          case 'warnings':
+          case 'errors':
+            return 'Status: ' + domain + ' is currently preloaded, but missing current requirements.';
+          default:
+            return 'Status: ' + domain + ' is currently preloaded, but unable to determine if it meets current requirements.';
+        }
       }
-      break;      
+      break;
 
     case 'rejected':
       if (status.message) {


### PR DESCRIPTION
* The site will now show all warnings and errors for already preloaded domains unless they are bulk domains.
* Introduces a new type called `DomainStateWithBulk`. I would like to come up with a better name than this. I'm also not sure where to put it.
* To keep the changeset small, I introduced a new field on `wantsBody` to handle the bulk status test assertions instead of moving everything to asserting the bulk status.

Fixes #55 