### PR TITLE
Minor CSS cleanup and tweaks.

### DIFF
--- a/frontend/static/css/form.css
+++ b/frontend/static/css/form.css
@@ -24,7 +24,7 @@ noscript {
   display: block;
   margin: 2em 4em;
   font-size: 1.5em;
-  color: gray;
+  color: #808080;
 }
 
 /******** result-waiting ********/
@@ -48,16 +48,20 @@ noscript {
   margin-bottom: 1em;
 }
 
-@keyframes spinnerRotate
-{
-  from { transform:rotate(0deg); }
-  to { transform:rotate(360deg); }
+@keyframes spinnerRotate {
+  from {
+    transform: rotate(0);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /******** result ********/
 
 #result {
-  padding: 1em 0em;
+  padding: 1em 0;
 }
 
 #result .issues {
@@ -69,7 +73,7 @@ noscript {
 }
 
 #result .issues-list div {
-  border-top: 1px solid rgb(127, 127, 127);
+  border-top: 1px solid #7f7f7f;
   /*background: rgba(255, 0, 0, 0.25);*/
   display: block;
   padding: 1em 2em;
@@ -77,7 +81,7 @@ noscript {
 }
 
 #result .issues .summary {
-  font-weight: bold;
+  font-weight: 700;
 }
 
 #result .issues .message {
@@ -91,13 +95,13 @@ noscript {
 }
 
 #result .issues-list div:last-child {
-  border-bottom: 1px solid rgb(127, 127, 127);
+  border-bottom: 1px solid #7f7f7f;
 }
 
 /******** submit-form ********/
 
 hr {
-  border: 1px solid #AAA;
+  border: 1px solid #aaa;
   border-bottom: none;
   margin: 1em 0 3em;
 }
@@ -106,7 +110,7 @@ hr {
   text-align: left;
   width: 80%;
   max-width: 30em;
-  margin: 0em auto;
+  margin: 0 auto;
 }
 
 #checkboxes input[type=checkbox] {
@@ -120,11 +124,11 @@ hr {
 }
 
 #oops {
-  color: rgb(160, 170, 160);
+  color: #a0aaa0;
 }
 
 #oops a {
-  color: rgb(130, 130, 140);
+  color: #82828c;
 }
 
 .subdomain-example {

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -5,53 +5,36 @@ html, body {
 }
 
 body {
-  background-color: #f5f5f5;
-  font-family: "Roboto", Helvetica, Tahoma, sans-serif;
-}
-
-.header{
-  font-size: 20px;
-  color: rgb(66, 66, 66);
-  letter-spacing: 0.02em;
-  display:flex;
-  align-items: center;
-  height: 64px;
-  padding: 0 16px 0 40px;
-
-  font-family: "Roboto", Helvetica, Tahoma, sans-serif;
+  background-color: #7f7f7f;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  padding: 2em 0;
 }
 
 .content {
-  padding: 80px 56px;
-  font-size: 14px;
+  padding: 2em 0;
   background-color: #ffffff;
   color: #424242;
   margin: 2em auto;
   max-width: 939px;
   width: calc(80% - 138px);
-  box-shadow:0 4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2);
+  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
   border-radius: 2px;
-
   line-height: 24px;
+  box-sizing: border-box;
+  min-width: 30em;
 }
 
-@media (max-width: 839px) {
-  .content {
-    width:calc(100% - 88px);
-    padding: 40px 28px;
-  }
-
-  .header {
-    height: 56px;
-  }
+h2 {
+  margin-top: 0;
 }
 
 h3 {
-  font-weight: normal;
-  margin: 48px 0px 24px;
-  font-size: 34px;
-  /* For a closer match of the original template: */
-  font-family: "Roboto", Helvetica, Tahoma, sans-serif;
+  font-weight: 400;
+  margin: 48px 0 24px;
+  font-size: 2em;
   line-height: 40px;
 }
 
@@ -60,23 +43,12 @@ p {
 }
 
 /* hstspreload general */
-
-body {
-  padding: 2em 0;
-}
-
-.content {
-  padding: 2em 0;
-  box-sizing: border-box;
-  min-width: 30em;
-}
-
 section {
   padding: 1em 4em;
 }
 
 section:target {
-  background: rgba(255, 0, 0, 0.1);
+  background-color: rgba(255, 0, 0, 0.1);
   border-top: 1px solid rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   margin-top: -1px;
@@ -93,16 +65,12 @@ a.hash-link:hover {
   text-decoration: underline;
 }
 
-h2 {
-  margin-top: 0;
-}
-
 .hidden {
   display: none;
 }
 
 .header-example {
-  background: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.1);
   padding: 0.25em 0.5em;
   box-sizing: border-box;
   line-height: 2em;
@@ -119,21 +87,52 @@ h2 {
 }
 
 /* Theming */
+.form {
+  background-color: #f2f2f2;
+}
 
-body { background: rgb(127, 127, 127);}
-.form   { background: rgb(242, 242, 242);}
+body.theme-green:not(.theme-remove) {
+  background-color: #0d904f;
+}
 
-body.theme-green:not(.theme-remove) { background: #0d904f; }
-body.theme-green .form   { background: #ddffee; }
+body.theme-green .form {
+  background-color: #ddffee;
+}
 
-body.theme-red:not(.theme-remove) { background:#c62828; }
-body.theme-red .form   { background: #ffebee; }
+body.theme-red:not(.theme-remove) {
+  background-color: #c62828;
+}
 
-body.theme-yellow:not(.theme-remove) { background: #fdd835; }
-body.theme-yellow .form   { background: #fffde7; }
+body.theme-red .form {
+  background-color: #ffebee;
+}
 
-.errors div { background: #ffcdd2; }
-.errors .summary { color: #c62828; }
+body.theme-yellow:not(.theme-remove) {
+  background-color: #fdd835;
+}
 
-.warnings div { background: #fff9c4; }
-.warnings .summary { color: #ff8f00; }
+body.theme-yellow .form {
+  background-color: #fffde7;
+}
+
+.errors div {
+  background-color: #ffcdd2;
+}
+
+.errors .summary {
+  color: #c62828;
+}
+
+.warnings div {
+  background-color: #fff9c4;
+}
+
+.warnings .summary {
+  color: #ff8f00;
+}
+
+@media (max-width: 839px) {
+  .content {
+    width: calc(100% - 88px);
+  }
+}


### PR DESCRIPTION
* use the native font stack
* use hex color values when possible for consistency and because it's shorter
* use numbered for-weight
* merge a couple of selectors
* remove zero from units
* use `background-color` instead of the `background` shorthand since only the background color is supposed to change
* style consistency changes
* remove unused selectors
