### PR TITLE
Propose a new whitelisted origin to cors.go

### DIFF
--- a/api/cors.go
+++ b/api/cors.go
@@ -17,6 +17,7 @@ var whitelistedHosts = map[string]bool{
 	"mozilla.github.io":       true,
 	"observatory.mozilla.org": true,
 	"a.ncsccs.com":            true,
+	"chksite.com":             true,
 }
 
 func allowOrigin(clientOrigin string) bool {


### PR DESCRIPTION
I am developing a site similar in concept to observatory.mozilla.org with a goal of being more approachable by a less technical audience.