### PR TITLE
Move static-data/.gitignore in the root .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /frontend/version
-/api/bulk_preloaded.go
+/static-data/bulk-preloaded.json

--- a/static-data/.gitignore
+++ b/static-data/.gitignore
@@ -1,2 +1,0 @@
-/bulk-preloaded.json
-/dos.yaml


### PR DESCRIPTION
Easier and better for maintenance to have everything in one place.

Also, clean up the entries.
