### PR TITLE
Add policy to entries added by the current auto-roller script.

### DIFF
--- a/scripts/roll_preload_list.py
+++ b/scripts/roll_preload_list.py
@@ -76,7 +76,7 @@ def update(pendingRemovals, pendingAdditions, entryStrings):
         yield l
     elif l == "    // END OF 1-YEAR BULK HSTS ENTRIES":
       for domain in sorted(pendingAdditions):
-        yield '    { "name": "%s", "include_subdomains": true, "mode": "force-https" },' % domain
+        yield '    { "name": "%s", "policy": "bulk-1-year", "include_subdomains": true, "mode": "force-https" },' % domain
       yield l
     else:
       yield l


### PR DESCRIPTION
This updates the current auto-roller script so that new entries are assigned the "bulk-1-year" policy.

I'd like to make the policy field required once all entries are assigned a policy, updating the auto-roller now might make the process a little easier.