### PR TITLE
Remove DoS error handler. It never worked.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,7 +4,3 @@ env: flex
 handlers:
 - url: /.*
   script: _go_app
-
-error_handlers:
-- error_code: dos_api_denial
-  file: static-data/dos-response.txt


### PR DESCRIPTION
I tried using it to mitigate an attack, but it turns out that App Engine DoS protection doesn't work for Flex / Managed Environment.

The handler also doesn't do anything useful anymore, since the error file is already gone from the repo.