### PR TITLE
trim() input for domain

### DIFF
--- a/frontend/static/js/view.js
+++ b/frontend/static/js/view.js
@@ -75,7 +75,7 @@ PreloadView.prototype = {
   },
 
   currentDomain: function() {
-    var domain = $('#domain').value;
+    var domain = $('#domain').value.trim();
     return extractDomain(domain);
   },
 


### PR DESCRIPTION
Leading and trailing whitespace is not currently removed, and is turned into `+` when the hostname is extracted.
We should `.trim()` the input before `extractDomain()` is called.