### PR TITLE
Add link to actual list

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -226,6 +226,13 @@
     </p>
   </section>
 
+  <section id="list">
+    <h2><a class="hash-link" href="#list">Getting the List</a></h2>
+    <p>
+      The HSTS preload list is part of the Chromium source code. You can download <a href="https://github.com/chromium/chromium/raw/master/net/http/transport_security_state_static.json">the HSTS preload list in JSON format here</a>.
+    </p>
+  </section>
+
   <section id="contact">
     <h2><a class="hash-link" href="#contact">Contact</a></h2>
     <p>


### PR DESCRIPTION
I think it would be nice if the webpage for the HSTS preload list contained info where to actually get the preload list.

The link goes to the github mirror of the chromium source, because the original on googlesource does not support direct downloading of the raw file.