### PR TITLE
Update Master to Main in bulk update script

### DIFF
--- a/scripts/update_bulk_preloaded.py
+++ b/scripts/update_bulk_preloaded.py
@@ -20,7 +20,7 @@ class State:
 
 def getRawText():
   log("Fetching preload list from Chromium source...\n")
-  return base64.b64decode(requests.get("https://chromium.googlesource.com/chromium/src/+/master/net/http/transport_security_state_static.json?format=TEXT").text)
+  return base64.b64decode(requests.get("https://chromium.googlesource.com/chromium/src/+/main/net/http/transport_security_state_static.json?format=TEXT").text)
 
 def extractBulkEntries(rawText):
   log("Extracting bulk entries...\n")


### PR DESCRIPTION
The Chromium repository stopped porting updates to its master branch in
lieu of the main branch, which causes hstspreload's awareness of
preloaded domains to diverge from chromium's. This change updates the
script to pull from the now-correct branch.