### PR TITLE
Update caniuse link to new pattern

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -97,7 +97,7 @@
       This is a list of sites that are hardcoded into Chrome as being HTTPS only.
     </p>
     <p>
-      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="https://caniuse.com/#feat=stricttransportsecurity">HSTS compatibility matrix</a>.)
+      Most major browsers (Chrome, <a href="https://blog.mozilla.org/security/2012/11/01/preloading-hsts/">Firefox</a>, Opera, Safari, <a href="https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/">IE 11 and Edge</a>) also have HSTS preload lists based on the Chrome list. (See the <a href="https://caniuse.com/stricttransportsecurity">HSTS compatibility matrix</a>.)
     </p>
   </section>
 


### PR DESCRIPTION
<https://caniuse.com/#feat=stricttransportsecurity> is being redirected to <https://caniuse.com/stricttransportsecurity> already, but skip that redirect this way 0:-)