### PR TITLE
Restore CI for linting and testing using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '^1.15.0'
+      - uses: actions/checkout@v3
+      - run: make lint
+      - run: make build
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ build:
 .PHONY: lint
 lint:
 	go vet ${PROJECT}
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+	staticcheck ${PROJECT}
 
 .PHONY: pre-commit
 pre-commit: lint build test

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -351,7 +351,7 @@ func TestAPI(t *testing.T) {
 
 		tt.handlerFunc(w, r)
 
-		contentType := w.HeaderMap.Get(http.CanonicalHeaderKey("Content-Type"))
+		contentType := w.Result().Header.Get("Content-Type")
 		if contentType != tt.wantContentType {
 			t.Errorf("[%s] Wrong content type: %s", tt.description, contentType)
 		}

--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -102,7 +102,7 @@ func (api API) Removable(w http.ResponseWriter, r *http.Request) {
 	if bulkState.Status == database.StatusPreloaded && bulkState.PreloadedDomain != domain {
 		ancestorDomain := bulkState.PreloadedDomain
 		_, ancestorHasParent := parentDomain(ancestorDomain)
-		issue := hstspreload.Issue{}
+		var issue hstspreload.Issue
 		if ancestorHasParent {
 			issue = hstspreload.Issue{
 				Code:    "server.removable.subdomain",

--- a/api/pending.go
+++ b/api/pending.go
@@ -9,7 +9,7 @@ import (
 
 func (api API) listDomainsWithStatus(w http.ResponseWriter, r *http.Request, status database.PreloadStatus, entryFormat string) {
 	if r.Method != "GET" {
-		http.Error(w, fmt.Sprintf("Wrong method. Requires GET."), http.StatusMethodNotAllowed)
+		http.Error(w, "Wrong method. Requires GET.", http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/api/update.go
+++ b/api/update.go
@@ -140,7 +140,7 @@ func (api API) Update(w http.ResponseWriter, r *http.Request) {
 		if written {
 			// The header and part of the body have already been sent, so we
 			// can't change the status code anymore.
-			fmt.Fprintf(w, msg)
+			fmt.Fprint(w, msg)
 		} else {
 			http.Error(w, msg, http.StatusInternalServerError)
 		}

--- a/database/database.go
+++ b/database/database.go
@@ -128,30 +128,6 @@ func (db DatastoreBacked) statesForQuery(query *datastore.Query) (states []Domai
 	return states, nil
 }
 
-// domainsForQuery returns the domains that match the given datastore query.
-func (db DatastoreBacked) domainsForQuery(query *datastore.Query) (domains []string, err error) {
-	// Set up the datastore context.
-	c, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	client, datastoreErr := db.backend.NewClient(c, db.projectID)
-	if datastoreErr != nil {
-		return domains, datastoreErr
-	}
-
-	keys, err := client.GetAll(c, query.KeysOnly(), nil)
-	if err != nil {
-		return domains, err
-	}
-
-	for _, key := range keys {
-		domain := key.Name
-		domains = append(domains, domain)
-	}
-
-	return domains, nil
-}
-
 // StateForDomain get the state for the given domain.
 // Note that the Name field of `state` will not be set.
 func (db DatastoreBacked) StateForDomain(domain string) (state DomainState, err error) {
@@ -184,5 +160,5 @@ func (db DatastoreBacked) AllDomainStates() (states []DomainState, err error) {
 // StatesWithStatus returns the states of domains with the given status in the database.
 func (db DatastoreBacked) StatesWithStatus(status PreloadStatus) (domains []DomainState, err error) {
 	return db.statesForQuery(
-		datastore.NewQuery("DomainState").Filter("Status =", string(status)))
+		datastore.NewQuery("DomainState").FilterField("Status", "=", string(status)))
 }

--- a/database/gcd/gcd_test.go
+++ b/database/gcd/gcd_test.go
@@ -1,10 +1,9 @@
 package gcd
 
 import "testing"
-import "github.com/chromium/hstspreload.org/database/gcd"
 
 func TestNewLocalBackend(t *testing.T) {
-	_, shutdown, err := gcd.NewLocalBackend()
+	_, shutdown, err := NewLocalBackend()
 	if err != nil {
 		t.Errorf("%s", err)
 	}

--- a/database/mock.go
+++ b/database/mock.go
@@ -28,7 +28,7 @@ func NewMock() (m Mock, mc *MockController) {
 
 // PutStates mock method
 func (m Mock) PutStates(updates []DomainState, logf func(format string, args ...interface{})) error {
-	if m.state.FailCalls == true {
+	if m.state.FailCalls {
 		return errors.New("forced failure")
 	}
 
@@ -40,7 +40,7 @@ func (m Mock) PutStates(updates []DomainState, logf func(format string, args ...
 
 // PutState mock method
 func (m Mock) PutState(update DomainState) error {
-	if m.state.FailCalls == true {
+	if m.state.FailCalls {
 		return errors.New("forced failure")
 	}
 
@@ -50,7 +50,7 @@ func (m Mock) PutState(update DomainState) error {
 
 // StateForDomain mock method
 func (m Mock) StateForDomain(domain string) (state DomainState, err error) {
-	if m.state.FailCalls == true {
+	if m.state.FailCalls {
 		return state, errors.New("forced failure")
 	}
 
@@ -63,7 +63,7 @@ func (m Mock) StateForDomain(domain string) (state DomainState, err error) {
 
 // AllDomainStates mock method
 func (m Mock) AllDomainStates() (states []DomainState, err error) {
-	if m.state.FailCalls == true {
+	if m.state.FailCalls {
 		return states, errors.New("forced failure")
 	}
 
@@ -75,7 +75,7 @@ func (m Mock) AllDomainStates() (states []DomainState, err error) {
 
 // StatesWithStatus mock method
 func (m Mock) StatesWithStatus(status PreloadStatus) (domains []DomainState, err error) {
-	if m.state.FailCalls == true {
+	if m.state.FailCalls {
 		return domains, errors.New("forced failure")
 	}
 

--- a/server.go
+++ b/server.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -98,7 +97,7 @@ func mustSetupAPI(local bool, bulkPreloadedEntries map[string]bool) (a api.API, 
 }
 
 func mustReadBulkPreloaded() api.DomainSet {
-	file, err := ioutil.ReadFile("static-data/bulk-preloaded.json")
+	file, err := os.ReadFile("static-data/bulk-preloaded.json")
 	exitIfNotNil(err)
 
 	var bulkPreloaded api.DomainSet


### PR DESCRIPTION
This closes https://github.com/chromium/hstspreload.org/issues/202

This is a followup to https://github.com/chromium/hstspreload.org/commit/dd68c7c8b5ee77fd66008500fc3d35140290a50d#commitcomment-55737219 that adds back linting and testing to CI using GitHub Actions.

We used to run `golint` in CI to catch issues, but it's [been deprecated](https://github.com/golang/lint) so I've replaced it with `staticcheck` (and fixed up resulting issues) per:

> **NOTE**: Golint is https://github.com/golang/go/issues/38968. There's no drop-in replacement for it, but tools such as [Staticcheck](https://staticcheck.io/) and go vet should be used instead.