### PR TITLE
Created new domain status: StatusPendingAutomatedRemoval

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,22 +118,18 @@ func TestAPI(t *testing.T) {
 	api.bulkPreloaded["removal-preloaded-bulk-ineligible.test"] = true
 
 	pr1 := map[string]hstspreload.Issues{
-		"garron.net":                                emptyIssues,
-		"badssl.com":                                issuesWithWarnings,
-		"example.com":                               issuesWithErrors,
-		"removal-pending-eligible.test":             emptyIssues,
-		"removal-pending-ineligible.test":           emptyIssues,
-		"automated-removal-pending-eligible.test":   emptyIssues,
-		"autoamted-removal-pending-ineligible.test": emptyIssues,
+		"garron.net":                      emptyIssues,
+		"badssl.com":                      issuesWithWarnings,
+		"example.com":                     issuesWithErrors,
+		"removal-pending-eligible.test":   emptyIssues,
+		"removal-pending-ineligible.test": emptyIssues,
 	}
 	rr1 := map[string]hstspreload.Issues{
-		"removal-preloaded-bulk-eligible.test":      emptyIssues,
-		"removal-preloaded-not-bulk-eligible.test":  emptyIssues,
-		"removal-preloaded-bulk-ineligible.test":    issuesWithErrors,
-		"removal-pending-eligible.test":             emptyIssues,
-		"removal-pending-ineligible.test":           issuesWithErrors,
-		"automated-removal-pending-eligible.test":   emptyIssues,
-		"automated-removal-pending-ineligible.test": issuesWithErrors,
+		"removal-preloaded-bulk-eligible.test":     emptyIssues,
+		"removal-preloaded-not-bulk-eligible.test": emptyIssues,
+		"removal-preloaded-bulk-ineligible.test":   issuesWithErrors,
+		"removal-pending-eligible.test":            emptyIssues,
+		"removal-pending-ineligible.test":          issuesWithErrors,
 	}
 
 	pl1 := preloadlist.PreloadList{Entries: []preloadlist.Entry{
@@ -156,6 +152,10 @@ func TestAPI(t *testing.T) {
 
 	jsonContentType := "application/json; charset=utf-8"
 	textContentType := "text/plain; charset=utf-8" // Errors
+
+	// tests for correct behavior for domains that are StatusPendingAutomatedRemoval in the database
+	pendingAutomatedRemovalDomain := database.DomainState{Name: "pending-automated-removal-domain", Status: database.StatusPendingAutomatedRemoval, IncludeSubDomains: true, Policy: preloadlist.Test}
+	api.database.PutState(pendingAutomatedRemovalDomain)
 
 	apiTestSequence := []apiTestCase{
 		// wrong HTTP method
@@ -220,6 +220,13 @@ func TestAPI(t *testing.T) {
 				Warnings: []hstspreload.Issue{{Code: "server.preload.already_pending"}},
 			}}},
 
+		// pending automated removal
+		{"pending automated removal", data1, failNone, api.PendingAutomatedRemoval, "GET", "",
+			200, jsonContentType, wantBody{text: "[\n    \"pending-automated-removal-domain\"\n]\n"}},
+		{"pending automated removal status", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal-domain",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "pending-automated-removal-domain", Status: database.StatusPendingAutomatedRemoval}}},
+
 		// update
 		{"garron.net pending", data1, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
@@ -239,12 +246,6 @@ func TestAPI(t *testing.T) {
 		{"create removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
-		// create automated removable pending
-		{"create automated removable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
-			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"create autoamted removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{issues: &emptyIssues}},
-
 		// removable
 		{"removable preloaded-bulk-eligible", data1, failNone, api.Removable, "GET", "?domain=removal-preloaded-bulk-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
@@ -259,10 +260,6 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 		{"removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
-		{"automated removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
-			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"automated removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// remove
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-preloaded-bulk-eligible.test",
@@ -274,10 +271,6 @@ func TestAPI(t *testing.T) {
 		{"remove pending-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 		{"remove pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
-		{"remove automated pending-eligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-eligible.test",
-			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"remove automated pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// Check removals
@@ -296,12 +289,6 @@ func TestAPI(t *testing.T) {
 		{"remove pending-ineligible", data1, failNone, api.Status, "GET", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "removal-pending-ineligible.test", Status: database.StatusPending}}},
-		{"remove automated pending-eligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-eligible.test",
-			200, jsonContentType, wantBody{state: &database.DomainState{
-				Name: "automated-removal-pending-eligible.test", Status: database.StatusPendingRemoval}}},
-		{"remove automated pending-ineligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{state: &database.DomainState{
-				Name: "automated-removal-pending-ineligible.test", Status: database.StatusPending}}},
 
 		// after update
 		{"submit after preloaded", data1, failNone, api.Submit, "POST", "?domain=garron.net",
@@ -348,7 +335,7 @@ func TestAPI(t *testing.T) {
 
 		// update with removal
 		{"update with removal", data2, failNone, api.Update, "GET", "",
-			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # of preloaded HSTS entries: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 3\nSuccess. 7 domain states updated.\n"}},
+			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # of preloaded HSTS entries: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 2\nSuccess. 6 domain states updated.\n"}},
 		{"garron.net after update with removal", data2, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "garron.net", Status: database.StatusRemoved}}},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -154,7 +154,7 @@ func TestAPI(t *testing.T) {
 	textContentType := "text/plain; charset=utf-8" // Errors
 
 	// tests for correct behavior for domains that are StatusPendingAutomatedRemoval in the database
-	pendingAutomatedRemovalDomain := database.DomainState{Name: "pending-automated-removal-domain", Status: database.StatusPendingAutomatedRemoval, IncludeSubDomains: true, Policy: preloadlist.Test}
+	pendingAutomatedRemovalDomain := database.DomainState{Name: "pending-automated-removal.test", Status: database.StatusPendingAutomatedRemoval, IncludeSubDomains: true, Policy: preloadlist.Test}
 	api.database.PutState(pendingAutomatedRemovalDomain)
 
 	apiTestSequence := []apiTestCase{
@@ -222,10 +222,10 @@ func TestAPI(t *testing.T) {
 
 		// pending automated removal
 		{"pending automated removal", data1, failNone, api.PendingAutomatedRemoval, "GET", "",
-			200, jsonContentType, wantBody{text: "[\n    \"pending-automated-removal-domain\"\n]\n"}},
-		{"pending automated removal status", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal-domain",
+			200, jsonContentType, wantBody{text: "[\n    \"pending-automated-removal.test\"\n]\n"}},
+		{"pending automated removal status", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
-				Name: "pending-automated-removal-domain", Status: database.StatusPendingAutomatedRemoval}}},
+				Name: "pending-automated-removal.test", Status: database.StatusPendingAutomatedRemoval}}},
 
 		// update
 		{"garron.net pending", data1, failNone, api.Status, "GET", "?domain=garron.net",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,22 +118,20 @@ func TestAPI(t *testing.T) {
 	api.bulkPreloaded["removal-preloaded-bulk-ineligible.test"] = true
 
 	pr1 := map[string]hstspreload.Issues{
-		"garron.net":                                emptyIssues,
-		"badssl.com":                                issuesWithWarnings,
-		"example.com":                               issuesWithErrors,
-		"removal-pending-eligible.test":             emptyIssues,
-		"removal-pending-ineligible.test":           emptyIssues,
-		"automated-removal-pending-eligible.test":   emptyIssues,
-		"autoamted-removal-pending-ineligible.test": emptyIssues,
+		"garron.net":                              emptyIssues,
+		"badssl.com":                              issuesWithWarnings,
+		"example.com":                             issuesWithErrors,
+		"removal-pending-eligible.test":           emptyIssues,
+		"removal-pending-ineligible.test":         emptyIssues,
+		"automated-removal-pending-eligible.test": emptyIssues,
 	}
 	rr1 := map[string]hstspreload.Issues{
-		"removal-preloaded-bulk-eligible.test":      emptyIssues,
-		"removal-preloaded-not-bulk-eligible.test":  emptyIssues,
-		"removal-preloaded-bulk-ineligible.test":    issuesWithErrors,
-		"removal-pending-eligible.test":             emptyIssues,
-		"removal-pending-ineligible.test":           issuesWithErrors,
-		"rautomated-removal-pending-eligible.test":  emptyIssues,
-		"automated-removal-pending-ineligible.test": issuesWithErrors,
+		"removal-preloaded-bulk-eligible.test":     emptyIssues,
+		"removal-preloaded-not-bulk-eligible.test": emptyIssues,
+		"removal-preloaded-bulk-ineligible.test":   issuesWithErrors,
+		"removal-pending-eligible.test":            emptyIssues,
+		"removal-pending-ineligible.test":          issuesWithErrors,
+		"rautomated-removal-pending-eligible.test": emptyIssues,
 	}
 
 	pl1 := preloadlist.PreloadList{Entries: []preloadlist.Entry{
@@ -239,10 +237,8 @@ func TestAPI(t *testing.T) {
 		{"create removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
-		// create autoamted removable pending
-		{"create automated rmeovable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
-			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"create autoamted removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-ineligible.test",
+		// create automated removable pending
+		{"create automated removable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
 		// removable
@@ -261,8 +257,6 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 		{"automated removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"automated removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// remove
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-preloaded-bulk-eligible.test",
@@ -277,8 +271,6 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 		{"remove automated pending-eligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
-		{"remove automated pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// Check removals
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Status, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -299,9 +291,6 @@ func TestAPI(t *testing.T) {
 		{"remove automated pending-eligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "automated-removal-pending-eligible.test", Status: database.StatusPendingRemoval}}},
-		{"remove automated pending-ineligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-ineligible.test",
-			200, jsonContentType, wantBody{state: &database.DomainState{
-				Name: "automated-removal-pending-ineligible.test", Status: database.StatusPending}}},
 
 		// after update
 		{"submit after preloaded", data1, failNone, api.Submit, "POST", "?domain=garron.net",
@@ -348,7 +337,7 @@ func TestAPI(t *testing.T) {
 
 		// update with removal
 		{"update with removal", data2, failNone, api.Update, "GET", "",
-			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # of preloaded HSTS entries: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 2\nSuccess. 6 domain states updated.\n"}},
+			200, textContentType, wantBody{text: "The preload list has 2 entries.|n- # of preloaded HSTS entriessss: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 2\nSuccess. 6 domain states updated.\n"}},
 		{"garron.net after update with removal", data2, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "garron.net", Status: database.StatusRemoved}}},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,20 +118,22 @@ func TestAPI(t *testing.T) {
 	api.bulkPreloaded["removal-preloaded-bulk-ineligible.test"] = true
 
 	pr1 := map[string]hstspreload.Issues{
-		"garron.net":                              emptyIssues,
-		"badssl.com":                              issuesWithWarnings,
-		"example.com":                             issuesWithErrors,
-		"removal-pending-eligible.test":           emptyIssues,
-		"removal-pending-ineligible.test":         emptyIssues,
-		"automated-removal-pending-eligible.test": emptyIssues,
+		"garron.net":                                emptyIssues,
+		"badssl.com":                                issuesWithWarnings,
+		"example.com":                               issuesWithErrors,
+		"removal-pending-eligible.test":             emptyIssues,
+		"removal-pending-ineligible.test":           emptyIssues,
+		"automated-removal-pending-eligible.test":   emptyIssues,
+		"autoamted-removal-pending-ineligible.test": emptyIssues,
 	}
 	rr1 := map[string]hstspreload.Issues{
-		"removal-preloaded-bulk-eligible.test":     emptyIssues,
-		"removal-preloaded-not-bulk-eligible.test": emptyIssues,
-		"removal-preloaded-bulk-ineligible.test":   issuesWithErrors,
-		"removal-pending-eligible.test":            emptyIssues,
-		"removal-pending-ineligible.test":          issuesWithErrors,
-		"rautomated-removal-pending-eligible.test": emptyIssues,
+		"removal-preloaded-bulk-eligible.test":      emptyIssues,
+		"removal-preloaded-not-bulk-eligible.test":  emptyIssues,
+		"removal-preloaded-bulk-ineligible.test":    issuesWithErrors,
+		"removal-pending-eligible.test":             emptyIssues,
+		"removal-pending-ineligible.test":           issuesWithErrors,
+		"automated-removal-pending-eligible.test":   emptyIssues,
+		"automated-removal-pending-ineligible.test": issuesWithErrors,
 	}
 
 	pl1 := preloadlist.PreloadList{Entries: []preloadlist.Entry{
@@ -240,6 +242,8 @@ func TestAPI(t *testing.T) {
 		// create automated removable pending
 		{"create automated removable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"create autoamted removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
 		// removable
 		{"removable preloaded-bulk-eligible", data1, failNone, api.Removable, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -257,6 +261,8 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 		{"automated removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"automated removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// remove
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-preloaded-bulk-eligible.test",
@@ -271,6 +277,8 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 		{"remove automated pending-eligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"remove automated pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// Check removals
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Status, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -291,6 +299,9 @@ func TestAPI(t *testing.T) {
 		{"remove automated pending-eligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "automated-removal-pending-eligible.test", Status: database.StatusPendingRemoval}}},
+		{"remove automated pending-ineligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "automated-removal-pending-ineligible.test", Status: database.StatusPending}}},
 
 		// after update
 		{"submit after preloaded", data1, failNone, api.Submit, "POST", "?domain=garron.net",
@@ -337,7 +348,7 @@ func TestAPI(t *testing.T) {
 
 		// update with removal
 		{"update with removal", data2, failNone, api.Update, "GET", "",
-			200, textContentType, wantBody{text: "The preload list has 2 entries.|n- # of preloaded HSTS entriessss: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 2\nSuccess. 6 domain states updated.\n"}},
+			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # of preloaded HSTS entries: 1\n- # to be added in this update: 0\n- # to be removed this update: 4\n- # to be self-rejected this update: 3\nSuccess. 7 domain states updated.\n"}},
 		{"garron.net after update with removal", data2, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "garron.net", Status: database.StatusRemoved}}},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,11 +118,12 @@ func TestAPI(t *testing.T) {
 	api.bulkPreloaded["removal-preloaded-bulk-ineligible.test"] = true
 
 	pr1 := map[string]hstspreload.Issues{
-		"garron.net":                      emptyIssues,
-		"badssl.com":                      issuesWithWarnings,
-		"example.com":                     issuesWithErrors,
-		"removal-pending-eligible.test":   emptyIssues,
-		"removal-pending-ineligible.test": emptyIssues,
+		"garron.net":                              emptyIssues,
+		"badssl.com":                              issuesWithWarnings,
+		"example.com":                             issuesWithErrors,
+		"removal-pending-eligible.test":           emptyIssues,
+		"removal-pending-ineligible.test":         emptyIssues,
+		"automated-removal-pending-eligible.test": emptyIssues,
 	}
 	rr1 := map[string]hstspreload.Issues{
 		"removal-preloaded-bulk-eligible.test":     emptyIssues,
@@ -130,6 +131,7 @@ func TestAPI(t *testing.T) {
 		"removal-preloaded-bulk-ineligible.test":   issuesWithErrors,
 		"removal-pending-eligible.test":            emptyIssues,
 		"removal-pending-ineligible.test":          issuesWithErrors,
+		"rautomated-removal-pending-eligible.test": emptyIssues,
 	}
 
 	pl1 := preloadlist.PreloadList{Entries: []preloadlist.Entry{
@@ -235,6 +237,10 @@ func TestAPI(t *testing.T) {
 		{"create removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
+		// create autoamted removable pending
+		{"create automated rmeovable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
+
 		// removable
 		{"removable preloaded-bulk-eligible", data1, failNone, api.Removable, "GET", "?domain=removal-preloaded-bulk-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
@@ -249,6 +255,8 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 		{"removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
+		{"automated-removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
 		// remove
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-preloaded-bulk-eligible.test",
@@ -261,6 +269,8 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 		{"remove pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
+		{"remove automated pending-eligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-eligible.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
 		// Check removals
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Status, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -278,6 +288,9 @@ func TestAPI(t *testing.T) {
 		{"remove pending-ineligible", data1, failNone, api.Status, "GET", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "removal-pending-ineligible.test", Status: database.StatusPending}}},
+		{"remove automated pending-eligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-eligible.test",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "automated-removal-pending-eligible.test", Status: database.StatusPendingRemoval}}},
 
 		// after update
 		{"submit after preloaded", data1, failNone, api.Submit, "POST", "?domain=garron.net",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -118,20 +118,22 @@ func TestAPI(t *testing.T) {
 	api.bulkPreloaded["removal-preloaded-bulk-ineligible.test"] = true
 
 	pr1 := map[string]hstspreload.Issues{
-		"garron.net":                              emptyIssues,
-		"badssl.com":                              issuesWithWarnings,
-		"example.com":                             issuesWithErrors,
-		"removal-pending-eligible.test":           emptyIssues,
-		"removal-pending-ineligible.test":         emptyIssues,
-		"automated-removal-pending-eligible.test": emptyIssues,
+		"garron.net":                                emptyIssues,
+		"badssl.com":                                issuesWithWarnings,
+		"example.com":                               issuesWithErrors,
+		"removal-pending-eligible.test":             emptyIssues,
+		"removal-pending-ineligible.test":           emptyIssues,
+		"automated-removal-pending-eligible.test":   emptyIssues,
+		"autoamted-removal-pending-ineligible.test": emptyIssues,
 	}
 	rr1 := map[string]hstspreload.Issues{
-		"removal-preloaded-bulk-eligible.test":     emptyIssues,
-		"removal-preloaded-not-bulk-eligible.test": emptyIssues,
-		"removal-preloaded-bulk-ineligible.test":   issuesWithErrors,
-		"removal-pending-eligible.test":            emptyIssues,
-		"removal-pending-ineligible.test":          issuesWithErrors,
-		"rautomated-removal-pending-eligible.test": emptyIssues,
+		"removal-preloaded-bulk-eligible.test":      emptyIssues,
+		"removal-preloaded-not-bulk-eligible.test":  emptyIssues,
+		"removal-preloaded-bulk-ineligible.test":    issuesWithErrors,
+		"removal-pending-eligible.test":             emptyIssues,
+		"removal-pending-ineligible.test":           issuesWithErrors,
+		"rautomated-removal-pending-eligible.test":  emptyIssues,
+		"automated-removal-pending-ineligible.test": issuesWithErrors,
 	}
 
 	pl1 := preloadlist.PreloadList{Entries: []preloadlist.Entry{
@@ -240,6 +242,8 @@ func TestAPI(t *testing.T) {
 		// create autoamted removable pending
 		{"create automated rmeovable pending eligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"create autoamted removable pending ineligible", data1, failNone, api.Submit, "POST", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
 
 		// removable
 		{"removable preloaded-bulk-eligible", data1, failNone, api.Removable, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -255,8 +259,10 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
 		{"removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=removal-pending-ineligible.test",
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
-		{"automated-removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
+		{"automated removable pending-eligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"automated removable pending-ineligible", data1, failNone, api.Removable, "GET", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// remove
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Remove, "POST", "?domain=removal-preloaded-bulk-eligible.test",
@@ -271,6 +277,8 @@ func TestAPI(t *testing.T) {
 			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 		{"remove automated pending-eligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"remove automated pending-ineligible", data1, failNone, api.Remove, "POST", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{issues: &issuesWithErrors}},
 
 		// Check removals
 		{"remove preloaded-bulk-eligible", data1, failNone, api.Status, "GET", "?domain=removal-preloaded-bulk-eligible.test",
@@ -291,6 +299,9 @@ func TestAPI(t *testing.T) {
 		{"remove automated pending-eligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-eligible.test",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "automated-removal-pending-eligible.test", Status: database.StatusPendingRemoval}}},
+		{"remove automated pending-ineligible", data1, failNone, api.Status, "GET", "?domain=automated-removal-pending-ineligible.test",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "automated-removal-pending-ineligible.test", Status: database.StatusPending}}},
 
 		// after update
 		{"submit after preloaded", data1, failNone, api.Submit, "POST", "?domain=garron.net",

--- a/api/pending.go
+++ b/api/pending.go
@@ -49,3 +49,11 @@ func (api API) PendingRemoval(w http.ResponseWriter, r *http.Request) {
 	api.listDomainsWithStatus(w, r, database.StatusPendingRemoval, `    "%s"%s
 `)
 }
+
+// PendingAutomatedRemoval returns a lsit of domain with status "pending-automated-removal"
+//
+// Example: Get /pending-automated-removal
+func (api API) PendingAutomatedRemoval(w http.ResponseWriter, r *http.Request) {
+	api.listDomainsWithStatus(w, r, database.StatusPendingAutomatedRemoval, `    "%s"%s
+`)
+}

--- a/database/domainstate.go
+++ b/database/domainstate.go
@@ -13,12 +13,13 @@ type PreloadStatus string
 
 // Values for PreloadStatus
 const (
-	StatusUnknown        = "unknown"
-	StatusPending        = "pending"
-	StatusPreloaded      = "preloaded"
-	StatusRejected       = "rejected"
-	StatusRemoved        = "removed"
-	StatusPendingRemoval = "pending-removal"
+	StatusUnknown                 = "unknown"
+	StatusPending                 = "pending"
+	StatusPreloaded               = "preloaded"
+	StatusRejected                = "rejected"
+	StatusRemoved                 = "removed"
+	StatusPendingRemoval          = "pending-removal"
+	StatusPendingAutomatedRemoval = "pending-automated-removal"
 )
 
 // DomainState represents the state stored for a domain in the hstspreload

--- a/scripts/roll_preload_list.py
+++ b/scripts/roll_preload_list.py
@@ -14,6 +14,10 @@ def getPendingRemovals():
   log("Fetching pending removal...\n")
   return requests.get("https://hstspreload.org/api/v2/pending-removal").json()
 
+def getPendingAutomatedRemovals():
+  log("Fetch pending automated removal... \n")
+  return requests.get("https://hstspreload.org/api/v2/pending-removal").json()
+
 def getRawText(preloadListPath):
   log("Fetching preload list from Chromium source...\n")
   with open(preloadListPath, "r") as f:
@@ -118,11 +122,10 @@ def checkForDupes(parsedList):
 
 def main():
   args = getArgs()
-
   rawText = getRawText(args.preload_list_path)
-  pendingRemovals = []
+  pendingRemovals = getPendingAutomatedRemovals()
   if not args.skip_removals:
-    pendingRemovals = getPendingRemovals()
+    pendingRemovals += getPendingRemovals()
   domainsToReject = []
   pendingAdditions = domainsToPreload(getPendingScan(args.pending_scan_path), domainsToReject)
   updated = update(pendingRemovals, pendingAdditions, chunks(rawText))

--- a/scripts/roll_preload_list.py
+++ b/scripts/roll_preload_list.py
@@ -16,7 +16,7 @@ def getPendingRemovals():
 
 def getPendingAutomatedRemovals():
   log("Fetch pending automated removal... \n")
-  return requests.get("https://hstspreload.org/api/v2/pending-removal").json()
+  return requests.get("https://hstspreload.org/api/v2/pending-automated-removal").json()
 
 def getRawText(preloadListPath):
   log("Fetching preload list from Chromium source...\n")
@@ -123,9 +123,9 @@ def checkForDupes(parsedList):
 def main():
   args = getArgs()
   rawText = getRawText(args.preload_list_path)
-  pendingRemovals = getPendingAutomatedRemovals()
+  pendingRemovals = []
   if not args.skip_removals:
-    pendingRemovals += getPendingRemovals()
+    pendingRemovals = getPendingRemovals() + getPendingAutomatedRemovals()
   domainsToReject = []
   pendingAdditions = domainsToPreload(getPendingScan(args.pending_scan_path), domainsToReject)
   updated = update(pendingRemovals, pendingAdditions, chunks(rawText))

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ func main() {
 
 	server.HandleFunc("/api/v2/pending", a.Pending)
 	server.HandleFunc("/api/v2/pending-removal", a.PendingRemoval)
+	server.HandleFunc("/api/v2/pending-automated-removal", a.PendingAutomatedRemoval)
 	server.HandleFunc("/api/v2/update", a.Update)
 
 	if *local {


### PR DESCRIPTION
With this new domain status, we will be able to properly check for domains that have failed the preload list checks too many times in our automated removal process, and thus should be removed from the preload list. We change these domains' status to StatusPendingAutomatedRemoval. We will use this status in the python script that generates a new source preload list by ensuring that domains that are marked pendingRemoval in the script includes domains that have requested removal from the preload list and the domains that have failed the automated checks too many times. 

This PR doesn't include any logic concerning when the domains will have their status' changed to StatusPendingAutomatedRemoval. That part is being created by my partner, @bkhushi.