### PR TITLE
Update golang runtime

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,8 @@
-runtime: go1.15
+runtime: go
 env: flex
 
-env_variables:
-  GODEBUG: "tls13=1"
+runtime_config:
+  operating_system: "ubuntu22"
 
 handlers:
 - url: /.*


### PR DESCRIPTION
Update app.yaml to use the latest golang runtime for app engine flex, which is currently go 1.20. (This change also removes a no longer needed environment variable.)