### PR TITLE
Fix AppEngine Cron access checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ pre-commit: lint build test
 .PHONY: deploy
 deploy: version
 	date
-	time gcloud app deploy app.yaml
-	gcloud app deploy cron.yaml
+	time gcloud app deploy app.yaml cron.yaml
 	date
 
 # Version file.

--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -390,7 +390,7 @@ func (api API) Remove(w http.ResponseWriter, r *http.Request) {
 // Example: GET /remove-ineligible-domains
 func (api API) RemoveIneligibleDomains(w http.ResponseWriter, r *http.Request) {
 	// ensures endpoint requests can only come from App Engine
-	if r.Header.Get("X-Appengine-Cron") != "true" || r.RemoteAddr != "0.1.0.2" {
+	if r.Header.Get("X-Appengine-Cron") != "true" {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,6 +1,6 @@
 cron: 
-- description: "Removes inneligible domains"
+- description: "Removes ineligible domains"
   url: "/api/v2/remove-ineligible-domains"
   schedule: every monday 09:00
-  timezone: america/new_york
+  timezone: America/New_York
 

--- a/hstsserver.go
+++ b/hstsserver.go
@@ -33,6 +33,8 @@ func hsts(w http.ResponseWriter, r *http.Request) (cont bool) {
 	}
 
 	switch {
+	case maybeAppEngineCron(r):
+		return true
 	case (r.Host == "hstspreload.appspot.com"):
 		redirectDomain := "hstspreload.appspot.com"
 		if isHTTPS {
@@ -41,7 +43,7 @@ func hsts(w http.ResponseWriter, r *http.Request) (cont bool) {
 		u := fmt.Sprintf("https://%s%s", redirectDomain, r.URL.Path)
 		http.Redirect(w, r, u, http.StatusMovedPermanently)
 		return false
-	case isHTTPS, isLocalhost(r.Host), maybeAppEngineCron(r):
+	case isHTTPS, isLocalhost(r.Host):
 		return true
 	default:
 		u := fmt.Sprintf("https://%s%s", r.Host, r.URL.Path)


### PR DESCRIPTION
Cron requests come in on the appspot.com hostname instead of hstspreload.org, so don't redirect the cron requester. The remote IP address isn't being properly populated in the http.Request.RemoteAddr field, so rely only on the X-Appengine-Cron header to authenticate that the request came from AppEngine Cron.