### PR TITLE
Fix performance issues with /api/v2/remove-ineligible-domains

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -14,7 +14,7 @@ const (
 	prodProjectID  = "hstspreload"
 
 	batchSize = 450
-	timeout   = 45 * time.Second
+	timeout   = 90 * time.Second
 
 	domainStateKind           = "DomainState"
 	ineligibleDomainStateKind = "IneligibleDomainState"
@@ -285,9 +285,10 @@ func (db DatastoreBacked) SetIneligibleDomainStates(updates []IneligibleDomainSt
 		values = append(values, state)
 		if len(keys) >= batchSize {
 			if err := set(keys, values); err != nil {
-				keys = keys[:0]
-				values = values[:0]
+				return err
 			}
+			keys = keys[:0]
+			values = values[:0]
 		}
 	}
 	return set(keys, values)


### PR DESCRIPTION
The main fix here is to run the hstspreload.EligibleDomain checks in parallel (up to a limit) instead of in series.