### PR TITLE
Support transition from pending-automated-removal to pending

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -210,13 +210,6 @@ func TestAPI(t *testing.T) {
 				Warnings: []hstspreload.Issue{{Code: "server.preload.already_pending"}},
 			}}},
 
-		// pending automated removal
-		{"pending automated removal", data1, failNone, api.PendingAutomatedRemoval, "GET", "",
-			200, jsonContentType, wantBody{text: "[\n    \"pending-automated-removal.test\"\n]\n"}},
-		{"pending automated removal status", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal.test",
-			200, jsonContentType, wantBody{state: &database.DomainState{
-				Name: "pending-automated-removal.test", Status: database.StatusPendingAutomatedRemoval}}},
-
 		// update
 		{"garron.net pending", data1, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
@@ -229,6 +222,18 @@ func TestAPI(t *testing.T) {
 			200, textContentType, wantBody{text: "The preload list has 7 entries.\n- # of preloaded HSTS entries: 6\n- # to be added in this update: 6\n- # to be removed this update: 0\n- # to be self-rejected this update: 0\nSuccess. 6 domain states updated.\n"}},
 		{"pending 3", data1, failNone, api.Pending, "GET", "",
 			200, jsonContentType, wantBody{text: "[\n]\n"}},
+
+		// pending automated removal
+		{"pending automated removal", data1, failNone, api.PendingAutomatedRemoval, "GET", "",
+			200, jsonContentType, wantBody{text: "[\n    \"pending-automated-removal.test\"\n]\n"}},
+		{"pending automated removal status", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal.test",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "pending-automated-removal.test", Status: database.StatusPendingAutomatedRemoval}}},
+		{"submit previously pending automated removal", data1, failNone, api.Submit, "POST", "?domain=pending-automated-removal.test",
+			200, jsonContentType, wantBody{issues: &emptyIssues}},
+		{"pending-automated-removal.test status is now pending", data1, failNone, api.Status, "GET", "?domain=pending-automated-removal.test",
+			200, jsonContentType, wantBody{state: &database.DomainState{
+				Name: "pending-automated-removal.test", Status: database.StatusPending}}},
 
 		// create removable pending
 		{"create removable pending eligible", data1, failNone, api.Submit, "POST", "?domain=removal-pending-eligible.test",

--- a/api/domain_handlers.go
+++ b/api/domain_handlers.go
@@ -224,6 +224,8 @@ func (api API) Submit(w http.ResponseWriter, r *http.Request) {
 		fallthrough
 	case database.StatusPendingRemoval:
 		fallthrough
+	case database.StatusPendingAutomatedRemoval:
+		fallthrough
 	case database.StatusRemoved:
 		putErr := api.database.PutState(database.DomainState{
 			Name:              domain,


### PR DESCRIPTION
If a domain has the pending-automated-removal status (from failing to meet the requirements) but is then fixed so that it meets the requirements before the automated removal gets processed, it should be able to transition out of the pending-automated-removal state.