### PR TITLE
Fix Update endpoint

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -135,6 +135,7 @@ func TestAPI(t *testing.T) {
 		{Name: "removal-preloaded-bulk-eligible.test", Mode: preloadlist.ForceHTTPS, IncludeSubDomains: true, Policy: preloadlist.Bulk18Weeks},
 		{Name: "removal-preloaded-not-bulk-eligible.test", Mode: preloadlist.ForceHTTPS, IncludeSubDomains: true, Policy: preloadlist.Test},
 		{Name: "removal-preloaded-bulk-ineligible.test", Mode: preloadlist.ForceHTTPS, IncludeSubDomains: true, Policy: preloadlist.BulkLegacy},
+		{Name: "pending-automated-removal.test", Mode: preloadlist.ForceHTTPS, IncludeSubDomains: true, Policy: preloadlist.Test},
 		{Name: "godoc.og", Mode: "", IncludeSubDomains: true},
 		{Name: "dev", Mode: preloadlist.ForceHTTPS, IncludeSubDomains: true},
 	}}
@@ -221,7 +222,7 @@ func TestAPI(t *testing.T) {
 		{"update database failure", data1, failDatabase, api.Update, "GET", "",
 			500, textContentType, wantBody{text: "Internal error: could not retrieve domain names previously marked as preloaded. (forced failure)\n\n"}},
 		{"update success", data1, failNone, api.Update, "GET", "",
-			200, textContentType, wantBody{text: "The preload list has 7 entries.\n- # of preloaded HSTS entries: 6\n- # to be added in this update: 6\n- # to be removed this update: 0\n- # to be self-rejected this update: 0\nSuccess. 6 domain states updated.\n"}},
+			200, textContentType, wantBody{text: "The preload list has 8 entries.\n- # to be added in this update: 6\n- # to be updated in this update: 0\n- # to be removed this update: 0\nSuccess. 6 domain states updated.\n"}},
 		{"pending 3", data1, failNone, api.Pending, "GET", "",
 			200, jsonContentType, wantBody{text: "[\n]\n"}},
 
@@ -332,7 +333,7 @@ func TestAPI(t *testing.T) {
 
 		// update with removal
 		{"update with removal", data2, failNone, api.Update, "GET", "",
-			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # of preloaded HSTS entries: 1\n- # to be added in this update: 0\n- # to be removed this update: 5\n- # to be self-rejected this update: 2\nSuccess. 7 domain states updated.\n"}},
+			200, textContentType, wantBody{text: "The preload list has 2 entries.\n- # to be added in this update: 0\n- # to be updated in this update: 0\n- # to be removed this update: 7\nSuccess. 7 domain states updated.\n"}},
 		{"garron.net after update with removal", data2, failNone, api.Status, "GET", "?domain=garron.net",
 			200, jsonContentType, wantBody{state: &database.DomainState{
 				Name: "garron.net", Status: database.StatusRemoved}}},
@@ -371,7 +372,7 @@ func TestAPI(t *testing.T) {
 		if tt.wantBody.text != "" {
 			text := w.Body.String()
 			if text != tt.wantBody.text {
-				t.Errorf("[%s] Body text does not match wanted: %#v", tt.description, text)
+				t.Errorf("[%s] Wanted body text %q, got %q", tt.description, tt.wantBody.text, text)
 			}
 		}
 

--- a/api/update_test.go
+++ b/api/update_test.go
@@ -118,8 +118,6 @@ func TestUpdate(t *testing.T) {
 					Name: "preloaded-custom.test",
 					Status: database.StatusRemoved,
 					IncludeSubDomains: true,
-					// TODO: the policy field should get cleared for removed domains.
-					Policy: preloadlist.Custom,
 				},
 			},
 		},
@@ -136,9 +134,7 @@ func TestUpdate(t *testing.T) {
 			[]database.DomainState{
 				{
 					Name: "preloaded.test",
-					Status: database.StatusRejected,
-					// TODO: This state transition should not have this message.
-					Message: "Domain was added and removed without being preloaded.",
+					Status: database.StatusRemoved,
 					IncludeSubDomains: true,
 				},
 			},
@@ -156,8 +152,7 @@ func TestUpdate(t *testing.T) {
 			[]database.DomainState{
 				{
 					Name: "preloaded.test",
-					// TODO: This should be StatusRejected.
-					Status: database.StatusPendingAutomatedRemoval,
+					Status: database.StatusRemoved,
 					IncludeSubDomains: true,
 				},
 			},
@@ -201,8 +196,7 @@ func TestUpdate(t *testing.T) {
 				},
 				{
 					Name: "pending-automated-removal.test",
-					// TODO: This should be StatusPendingAutomatedRemoval
-					Status: database.StatusPreloaded,
+					Status: database.StatusPendingAutomatedRemoval,
 					IncludeSubDomains: true,
 					Policy: preloadlist.Bulk1Year,
 				},
@@ -232,9 +226,7 @@ func TestUpdate(t *testing.T) {
 					Name: "preloaded.test",
 					Status: database.StatusPreloaded,
 					IncludeSubDomains: true,
-					// TODO: Uncomment the following line when
-					// the functionality under test is fixed.
-					// Policy: preloadlist.Bulk1Year,
+					Policy: preloadlist.Bulk1Year,
 				},
 			},
 		},

--- a/database/domainstate.go
+++ b/database/domainstate.go
@@ -18,6 +18,7 @@ const (
 	StatusUnknown                 = "unknown"
 	StatusPending                 = "pending"
 	StatusPreloaded               = "preloaded"
+	// StatusRejected is deprecated. StatusRemoved should be used instead.
 	StatusRejected                = "rejected"
 	StatusRemoved                 = "removed"
 	StatusPendingRemoval          = "pending-removal"
@@ -83,7 +84,7 @@ func (s DomainState) Equal(s2 DomainState) bool {
 // Only the name, preload status, include subdomains boolean and policy is preserved during the conversion.
 func (s DomainState) ToEntry() preloadlist.Entry {
 	mode := preloadlist.ForceHTTPS
-	if s.Status != StatusPreloaded {
+	if s.Status != StatusPreloaded && s.Status != StatusPendingRemoval && s.Status != StatusPendingAutomatedRemoval {
 		mode = ""
 	}
 	return preloadlist.Entry{Name: s.Name, Mode: mode, IncludeSubDomains: s.IncludeSubDomains, Policy: s.Policy}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go/datastore v1.15.0
-	github.com/chromium/hstspreload v0.0.0-20230717215815-2404b4b967f9
+	github.com/chromium/hstspreload v0.0.0-20240911231609-cc9e2f8f2623
 	golang.org/x/net v0.23.0
 	google.golang.org/api v0.149.0
 	google.golang.org/grpc v1.59.0

--- a/go.sum
+++ b/go.sum
@@ -949,6 +949,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chromium/hstspreload v0.0.0-20230717215815-2404b4b967f9 h1:lUjpcxlnalltzHmS0ljbLvTVNyn+D9SlaVkFzNKvE6o=
 github.com/chromium/hstspreload v0.0.0-20230717215815-2404b4b967f9/go.mod h1:wnaDPQdV/ehNVGxLu9m5/NWnVHEizalu4/Z47anr3mg=
+github.com/chromium/hstspreload v0.0.0-20240911231609-cc9e2f8f2623 h1:XEjUCFrFn3Xml+OHwg+rmRJ2C7PoBtT9BmvRpdiukpw=
+github.com/chromium/hstspreload v0.0.0-20240911231609-cc9e2f8f2623/go.mod h1:aL/chD5x+u+u7eA4Ql7XCp8K2bAoy4qEiR7pgdWSDJk=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
Multiple state transitions in the Update endpoint were broken. This fixes those transitions and deprecates the Rejected status in favor of Removed.