### PR TITLE
[README.md] Update the development code snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <h1 align="center">hstspreload.org</h1>
 </p>
 
-
 This folder contains the source for the HSTS preload list submission website at [hstspreload.org](https://hstspreload.org/).
 
 See [github.com/chromium/hstspreload](https://github.com/chromium/hstspreload) for the core library that checks websites against the submission requirements.
@@ -18,11 +17,10 @@ Requirements
 - A `go` development environment.
 - The `java` commandline program for running JAR files (for the Cloud Datastore Emulator).
 
-  ```shell
-  go get github.com/chromium/hstspreload.org
-  cd $GOPATH/src/github.com/chromium/hstspreload.org
-  make serve
-  ```
+```shell
+git clone https://github.com/chromium/hstspreload.org && cd hstspreload.org
+make serve
+```
 
 The first time you run it, `make serve` will download the [Cloud Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator) (≈115MB) to a cache directory.
 
@@ -30,7 +28,9 @@ The first time you run it, `make serve` will download the [Cloud Datastore Emula
 
 If you have access to the Google Cloud `hstspreload` project:
 
-    make deploy
+```shell
+make deploy
+```
 
 Unfortunately, this usually takes 5-10 minutes.
 


### PR DESCRIPTION
`go get` no longer works out of the box, so a simple clone is more appropriate.

I've also updated both code snippets in the file to use the same code fences tagged with `shell`.