### PR TITLE
Process /api/v2/remove-ineligible-domains in shards

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,6 +1,17 @@
 cron: 
-- description: "Removes ineligible domains"
-  url: "/api/v2/remove-ineligible-domains"
-  schedule: every monday 09:00
+- description: "Remove ineligible domains ['','e')"
+  url: "/api/v2/remove-ineligible-domains?end=e"
+  schedule: every monday 9:00
   timezone: America/New_York
-
+- description: "Remove ineligible domains ['e','l')"
+  url: "/api/v2/remove-ineligible-domains?start=e&end=l"
+  schedule: every monday 11:00
+  timezone: America/New_York
+- description: "Remove ineligible domains ['l','s')"
+  url: "/api/v2/remove-ineligible-domains?start=l&end=s"
+  schedule: every monday 13:00
+  timezone: America/New_York
+- description: "Remove ineligible domains ['s','')"
+  url: "/api/v2/remove-ineligible-domains?start=s"
+  schedule: every monday 15:00
+  timezone: America/New_York

--- a/database/database.go
+++ b/database/database.go
@@ -27,6 +27,7 @@ type Database interface {
 	StateForDomain(string) (DomainState, error)
 	StatesForDomains([]string) ([]DomainState, error)
 	AllDomainStates() ([]DomainState, error)
+	DomainStatesInRange(start, end string) ([]DomainState, error)
 	StatesWithStatus(PreloadStatus) ([]DomainState, error)
 	GetIneligibleDomainStates(domains []string) (states []IneligibleDomainState, err error)
 	SetIneligibleDomainStates(updates []IneligibleDomainState, logf func(format string, args ...interface{})) error
@@ -206,6 +207,17 @@ func (db DatastoreBacked) StatesForDomains(domains []string) (states []DomainSta
 // AllDomainStates gets the states of all domains in the database.
 func (db DatastoreBacked) AllDomainStates() (states []DomainState, err error) {
 	return db.statesForQuery(datastore.NewQuery("DomainState"))
+}
+
+func (db DatastoreBacked) DomainStatesInRange(start, end string) ([]DomainState, error) {
+	query := datastore.NewQuery(domainStateKind)
+	if start != "" {
+		query = query.FilterField("__key__", ">=", datastore.NameKey(domainStateKind, start, nil))
+	}
+	if end != "" {
+		query = query.FilterField("__key__", "<", datastore.NameKey(domainStateKind, end, nil))
+	}
+	return db.statesForQuery(query)
 }
 
 // StatesWithStatus returns the states of domains with the given status in the database.

--- a/database/mock.go
+++ b/database/mock.go
@@ -87,6 +87,21 @@ func (m Mock) AllDomainStates() (states []DomainState, err error) {
 	return states, nil
 }
 
+// DomainStatesInRange mock method
+func (m Mock) DomainStatesInRange(start, end string) ([]DomainState, error) {
+	if m.state.FailCalls{
+		return nil, errors.New("forced failure")
+	}
+
+	states := []DomainState{}
+	for name, state := range m.ds {
+		if (start == "" || name >= start) && (end == "" || name < end) {
+			states = append(states, state)
+		}
+	}
+	return states, nil
+}
+
 // StatesWithStatus mock method
 func (m Mock) StatesWithStatus(status PreloadStatus) (domains []DomainState, err error) {
 	if m.state.FailCalls {


### PR DESCRIPTION
Processing all domains at once is failing to complete. Adding query parameters to the endpoint to have it process a subset of the domains on each run should result in each run using less resources and taking less time. The cron configuration is changed to split the work into 4 approximately evenly sized shards.