### PR TITLE
Mark IneligibleDomainState.Scans as noindex

### DIFF
--- a/database/ineligibledomainstate.go
+++ b/database/ineligibledomainstate.go
@@ -15,7 +15,7 @@ type IneligibleDomainState struct {
 	// in the stored value.
 	Name string `datastore:"-" json:"name"`
 	// Scans is where information of the checks are stored
-	Scans []Scan `json:"-"`
+	Scans []Scan `datastore:",noindex" json:"-"`
 	//  The policy under which the domain is part of the
 	//  preload list. “bulk-18-weeks” or “bulk-1-year”
 	Policy preloadlist.PolicyType `json:"policy"`


### PR DESCRIPTION
Some writes of IneligibleDomainStates are failing with an error of:

failed: datastore: datastore: datastore: datastore: string property too long to index for a Property with Name "Message" at index 0 for a Property with Name "Errors" for a Property with Name "Issues" at index 1 for a Property with Name "Scans"`

Setting `noindex`
(see https://pkg.go.dev/cloud.google.com/go/datastore@v1.20.0#hdr-Properties) on the Scans field should resolve this issue. We never query based on the Scans field, so not indexing it should be fine.